### PR TITLE
feat: add nightly terraform apply cronjob for #44

### DIFF
--- a/.github/workflows/nightly-apply.yml
+++ b/.github/workflows/nightly-apply.yml
@@ -2,7 +2,7 @@ name: Nightly Terraform Apply
 
 on:
   schedule:
-    - cron: '0 22 * * *'  # 10 PM UTC = midnight Turkey time 
+    - cron: '0 21 * * *'  # 9 PM UTC = midnight Turkey time (UTC+3 currently)
   workflow_dispatch:       # Manual trigger
 
 permissions:
@@ -11,6 +11,10 @@ permissions:
 
 env:
   AWS_TF_ROLE_ARN: ${{ vars.AWS_TF_ROLE_ARN }}
+ 
+  TF_VAR_github_organization: "BKT-DevOps"
+  TF_VAR_github_token: ${{ secrets.ORG_PAT }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   terraform-nightly-apply:
@@ -35,10 +39,6 @@ jobs:
       - name: Terraform Init
         id: init
         run: terraform init
-        env:
-          TF_VAR_github_organization: "BKT-DevOps"
-          TF_VAR_github_token: ${{ secrets.ORG_PAT }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Terraform Validate
         id: validate
@@ -47,15 +47,7 @@ jobs:
       - name: Terraform Plan
         id: plan
         run: terraform plan -no-color
-        env:
-          TF_VAR_github_organization: "BKT-DevOps"
-          TF_VAR_github_token: ${{ secrets.ORG_PAT }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Terraform Apply
         id: apply
         run: terraform apply -auto-approve
-        env:
-          TF_VAR_github_organization: "BKT-DevOps"
-          TF_VAR_github_token: ${{ secrets.ORG_PAT }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<details open>
<summary><strong>🇹🇷 Türkçe</strong></summary>
<br>

## 🎯 İlgili Görev (Task)

Task Ticket Number #44

## 📝 Açıklama
GitHub organizasyonunda manuel yapılan değişiklikleri önlemek için gece yarısı otomatik çalışan bir cronjob workflow'u eklendi.

**Özellikler:**
- Her gece 22:00 UTC'de (Türkiye saatiyle gece yarısı) otomatik çalışır
- Manuel eklenen kullanıcıları/izinleri otomatik olarak kaldırır
- Terraform plan ve apply komutlarını çalıştırır
- Manuel tetikleme özelliği bulunur (`workflow_dispatch`)


</details>

---

<details>
<summary><strong>🇬🇧 English</strong></summary>
<br>

## 🎯 Related Task

Task Ticket Number #44

## 📝 Description
Added a nightly cronjob workflow to prevent manual changes in the GitHub organization.

**Features:**
- Runs automatically daily at 22:00 UTC (midnight Turkey time)
- Automatically removes manually added users/permissions
- Executes Terraform plan and apply commands
- Includes manual trigger capability (`workflow_dispatch`)


</details>